### PR TITLE
Send photos as document to avoid compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ The application takes care of de-duplicating posts in scheduled sends, and doesn
 
 ## Credits
 - The heavylifting of generating a beautiful image of a Reddit post is the credit of the [Shareddit](https://github.com/logankuzyk/shareddit) project. For this application, I am using [my custom fork](https://github.com/rounakdatta/shareddit) which supports some additional functionalities atop that.
-- The logo for the project was generated [Gooey](https://gooey.ai) which is a cool platform for running Stable Diffusion Img2Img models.
+- The logo for the project was generated using [Gooey](https://gooey.ai) which is a cool platform for running Stable Diffusion Img2Img models.
 
 [^1]: There is a saying that your Reddit account can say more about your personality that your Google account / something else ;)

--- a/telegram.js
+++ b/telegram.js
@@ -83,7 +83,7 @@ bot.onText(/\/getall/, (msg) => {
 
         imageFiles.forEach(imgFileName => {
             const fullImgFileName = path.join(baseDirectory, imgFileName);
-            bot.sendPhoto(msg.chat.id, fullImgFileName)
+            bot.sendDocument(msg.chat.id, fullImgFileName)
         });
 
         bot.sendMessage(msg.chat.id, "Your upvoted posts are ready!");
@@ -115,7 +115,7 @@ function processPendingCollection() {
                 // condition where the row doesn't exist or `processed` is FALSE
                 if (!existsRow || existsRow.processed === 0) {
                     const fullImgFileName = path.join(baseDirectory, imgFileName);
-                    bot.sendPhoto(chatId, fullImgFileName)
+                    bot.sendDocument(chatId, fullImgFileName)
                     db.prepare('INSERT INTO processed_state (chat_id, post_id, processed) VALUES (?, ?, 1)').run(chatId, imgFileName);
                 }
             });


### PR DESCRIPTION
Reddit threads can be long sometimes, and since Telegram compresses images by default, they might end up unreadable in some cases. There's a workaround here - sending the images as documents instead.